### PR TITLE
Fix bundle data when the language isn't English

### DIFF
--- a/CustomCommunityCentre/Core/BundleManager.cs
+++ b/CustomCommunityCentre/Core/BundleManager.cs
@@ -145,7 +145,7 @@ namespace CustomCommunityCentre
 					rng: r);
 
 				// Add bundle data entries, ignoring existing values for mod compatibility
-				Dictionary<string, string> oldBundleData = Game1.netWorldState.Value.BundleData;
+				Dictionary<string, string> oldBundleData = Game1.netWorldState.Value.GetUnlocalizedBundleData();
 				bundleData = oldBundleData
 					.Union(bundleData.Where(pair => !oldBundleData.ContainsKey(pair.Key)))
 					.ToDictionary(pair => pair.Key, pair => pair.Value);


### PR DESCRIPTION
When the language isn't English, opening the game menu's shortcut to the Community Centre bundles, and accessing non-custom bundles in the Community Center fail because the bundleData has a duplicate localized name at the end eg `Spring Crops/O 465 20/24 1 0 188 1 0 190 1 0 192 1 0/0/Colture Primaverili/Colture Primaverili`. I think this fixes it.

